### PR TITLE
feat: update device configuration based on CUDA_VISIBLE_DEVICES envir…

### DIFF
--- a/vox_box/cmd/start.py
+++ b/vox_box/cmd/start.py
@@ -7,7 +7,7 @@ from vox_box.logging import setup_logging
 from vox_box.config import Config
 from vox_box.server.model import ModelInstance
 from vox_box.server.server import Server
-from vox_box.utils.model import parse_and_set_cuda_visible_devices
+from vox_box.utils.model import preconfigure_faster_whisper_env
 
 
 logger = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ def run(args: argparse.Namespace):
     try:
         cfg = parse_args(args)
         setup_logging(cfg.debug)
-        parse_and_set_cuda_visible_devices(cfg)
+        preconfigure_faster_whisper_env(cfg)
 
         logger.info("Starting with arguments: %s", args._get_kwargs())
 

--- a/vox_box/utils/model.py
+++ b/vox_box/utils/model.py
@@ -1,7 +1,8 @@
 import logging
 import os
+import re
 import time
-from typing import Dict
+from typing import Dict, Optional
 
 from vox_box.config import Config
 
@@ -24,11 +25,28 @@ def create_model_dict(id: str, **kwargs) -> Dict:
     return d
 
 
-def parse_and_set_cuda_visible_devices(cfg: Config):
+def preconfigure_faster_whisper_env(cfg: Config):
     """
-    Parse CUDA device in format cuda:1 and set CUDA_VISIBLE_DEVICES accordingly.
+    Due to faster-whisper's problematic handling of device parameters, CUDA_VISIBLE_DEVICES requires special configuration.
+    There are 3 methods to specify the GPU device for faster-whisper models:
+    1. Manually set `CUDA_VISIBLE_DEVICES={gpu_index}` and use "--device cuda:0" in CLI parameters.
+    2. If env `IS_FASTER_WHISPER` is unset AND the model path/name contains "faster-whisper", CUDA_VISIBLE_DEVICES will be set based on the GPU selector's device choice.
+    3. When `IS_FASTER_WHISPER=True`, CUDA_VISIBLE_DEVICES will be set based on the GPU selector's device choice.
     """
-    if cfg.device.startswith("cuda:"):
+    is_faster_whisper: Optional[bool] = None
+    if os.getenv("IS_FASTER_WHISPER"):
+        is_faster_whisper = os.getenv("IS_FASTER_WHISPER") in ("true", "1", "yes", "y")
+
+    if is_faster_whisper is False:
+        return
+
+    # If unset is_faster_whisper, check if the model name contains "faster-whisper"
+    if is_faster_whisper is None and re.search(
+        r"faster.*whisper", cfg.model, re.IGNORECASE
+    ):
+        is_faster_whisper = True
+
+    if is_faster_whisper is True and cfg.device.startswith("cuda:"):
         device_index = cfg.device.split(":")[1]
         if device_index.isdigit():
             os.environ["CUDA_VISIBLE_DEVICES"] = device_index


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/2484

After modified, I tested the cosyvoice2, bark-small, dia, and fun-asr models, all of which can be manually configured to run on GPU1.

