### PR TITLE
Fix: Prevent TypeError in re.search when cfg.model is None

### DIFF
--- a/vox_box/utils/model.py
+++ b/vox_box/utils/model.py
@@ -41,8 +41,10 @@ def preconfigure_faster_whisper_env(cfg: Config):
         return
 
     # If unset is_faster_whisper, check if the model name contains "faster-whisper"
-    if is_faster_whisper is None and re.search(
-        r"faster.*whisper", cfg.model, re.IGNORECASE
+    if (
+        is_faster_whisper is None
+        and isinstance(cfg.model, str)
+        and re.search(r"faster.*whisper", cfg.model, re.IGNORECASE)
     ):
         is_faster_whisper = True
 


### PR DESCRIPTION
The Bug: 

The app crashes if you run it in a fresh installation. This is because the code tries to do a text search (re.search) on the model name (cfg.model), but cfg.model is None when no model is provided, which causes an error. 

The Fix: 

I added a check right before the text search. It uses isinstance(cfg.model, str) to make sure the model name is a string first. If it's None, the search is skipped, which prevents the crash. 